### PR TITLE
Added Support For Ubuntu 25.04 WSL amd64 and Arm64

### DIFF
--- a/distributions/DistributionInfo.json
+++ b/distributions/DistributionInfo.json
@@ -6,11 +6,11 @@
                 "FriendlyName": "Ubuntu",
                 "Default": true,
                 "Amd64Url": {
-                    "Url": "https://releases.ubuntu.com/noble/ubuntu-24.04.2-wsl-amd64.wsl",
+                    "Url": "https://releases.ubuntu.com/plucky/ubuntu-25.04-wsl-amd64.wsl",
                     "Sha256": "5d1eea52103166f1c460dc012ed325c6eb31d2ce16ef6a00ffdfda8e99e12f43"
                 },
                 "Arm64Url": {
-                    "Url": "https://cdimages.ubuntu.com/releases/24.04.2/release/ubuntu-24.04.2-wsl-arm64.wsl",
+                    "Url": "https://cdimages.ubuntu.com/releases/25.04/release/ubuntu-25.04-wsl-arm64.wsl",
                     "Sha256": "75e6660229fabb38a6fdc1c94eec7d834a565fa58a64b7534e540da5319b2576"
                 }
             },


### PR DESCRIPTION
Whlie Checking For Any Updates In The Ubuntu 25.04 Releae Page There Was A WSL Image So Yeah I Chaged It!